### PR TITLE
add Fedora dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ In both configurations, the badge identifies itself on the USB as
   or
     sudo apt install python3-usb python3-pil
 
+### Required dependencies on Fedora Systems
+
+    sudo dnf install hidapi python3-hidapi python3-pillow python3-pyusb
+
 ### Required dependencies on Mac Systems
 
     sudo easy_install pip


### PR DESCRIPTION
This adds the `dnf` command needed on Fedora systems wishing to use `led-name-badge-ls32`.

With the dependencies installed, I was able to successfully program my badge using _Fedora 31 x86_64_