### PR TITLE
Added custom rendering support for badges with vid=204c, pid=4359

### DIFF
--- a/tests/test_lednamebadge_api.py
+++ b/tests/test_lednamebadge_api.py
@@ -9,8 +9,9 @@ class Test(abstract_write_method_test.AbstractWriteMethodTest):
         methods, output = self.call_info_methods()
         self.assertDictEqual({
             'hidapi': ('Program a device connected via USB using the pyhidapi package and libhidapi.', True),
-            'libusb': ('Program a device connected via USB using the pyusb package and libusb.', True)},
-            methods)
+            'libusb': ('Program a device connected via USB using the pyusb package and libusb.', True),
+            'pyserial': ('Program a device with the open-source firmware, connected via USB, using the pyserial package.', False)
+        }, methods)
 
     def test_get_device_ids(self):
         device_ids, output = self.call_info_ids('libusb')
@@ -48,7 +49,7 @@ class Test(abstract_write_method_test.AbstractWriteMethodTest):
     def call_info_ids(self, method):
         self.print_test_conditions(True, True, True, '-', '-')
         method_obj, output, _ = self.prepare_modules(True, True, True,
-                                                     lambda m: m.get_available_device_ids(method))
+                                                     lambda m: m.get_available_device_ids(method,vid=0x0416, pid=0x5020))
         return method_obj, output
 
     def call_write(self, method):

--- a/tests/test_lednamebadge_select_method.py
+++ b/tests/test_lednamebadge_select_method.py
@@ -157,7 +157,7 @@ class Test(abstract_write_method_test.AbstractWriteMethodTest):
     def call_find(self, pyusb_available, pyhidapi_available, device_available, method, device_id):
         self.print_test_conditions(pyusb_available, pyhidapi_available, device_available, method, device_id)
         method_obj, output, _ = self.prepare_modules(pyusb_available, pyhidapi_available, device_available,
-                                                  lambda m: m._find_write_method(method, device_id))
+                                                  lambda m: m._find_write_method(method, device_id, vid=0x0416, pid=0x5020))
         self.assertEqual(pyusb_available, 'usb.core detected' in output)
         self.assertEqual(pyhidapi_available, 'pyhidapi detected' in output)
         return method_obj, output


### PR DESCRIPTION
- Fixes #15 
- Packet structure is significantly different compared to the existing badge.
- Wanted to re-use the font generation setup.
- Currently only still text/bitmap is supported. Need to figure out the fine level encodings for speed/animation etc.

## Summary by Sourcery

Enable dual-protocol support by auto-detecting badge type via VID/PID and routing data through either the legacy header-based format or a new compact chunk-based encoding, extend APIs accordingly, and update tests to cover the changes.

New Features:
- Add custom rendering protocol for badges with VID=0x204c and PID=0x4359
- Introduce automatic device detection to choose between custom and original badge logic

Enhancements:
- Extend all write methods and device selection APIs to accept vendor and product IDs
- Refactor find_write_method, get_available_devices, open, and get_available_device_ids to propagate vid/pid
- Preserve original protocol logic under a renamed header method and static packet definitions
- Implement get_pixel_map and encode_custom_logic utilities for custom two-column chunk encoding

Tests:
- Include pyserial in the available write methods list under tests
- Update tests to pass vid/pid parameters when selecting available devices and write methods